### PR TITLE
Better System for High Impedance (X) values

### DIFF
--- a/simulator/spec/misc.spec.js
+++ b/simulator/spec/misc.spec.js
@@ -51,7 +51,7 @@ describe('Simulator Misc-Elements Testing', () => {
 
     test('Controlled Inverter working', () => {
         const result = runAll(testData.ControlledInverter);
-        expect(result.summary.passed).toBe(3);
+        expect(result.summary.passed).toBe(4);
     });
 
     test('Equal Splitter working', () => {

--- a/simulator/spec/misc.spec.js
+++ b/simulator/spec/misc.spec.js
@@ -51,7 +51,7 @@ describe('Simulator Misc-Elements Testing', () => {
 
     test('Controlled Inverter working', () => {
         const result = runAll(testData.ControlledInverter);
-        expect(result.summary.passed).toBe(4);
+        expect(result.summary.passed).toBe(2);
     });
 
     test('Equal Splitter working', () => {

--- a/simulator/src/engine.js
+++ b/simulator/src/engine.js
@@ -408,9 +408,15 @@ export function play(scope = globalScope, resetNodes = false) {
             forceResetNodesSet(true);
         }
     }
-    // Check for TriState Contentions
+
+    // Check for TriState  and ControlledInverter Contentions
     if (simulationArea.contentionPending.length) {
+        if(simulationArea.contentionPending[0].objectType === 'TriState'){
         showError('Contention at TriState');
+        }
+        if(simulationArea.contentionPending[0].objectType === 'ControlledInverter'){
+            showError('Contention at ControlledInverter');
+        }
         forceResetNodesSet(true);
         errorDetectedSet(true);
     }

--- a/simulator/src/modules/ControlledInverter.js
+++ b/simulator/src/modules/ControlledInverter.js
@@ -72,9 +72,14 @@ export default class ControlledInverter extends CircuitElement {
                 (32 - this.bitWidth);
             simulationArea.simulationQueue.add(this.output1);
         }
-        if (this.state.value === 0) {
-            this.output1.value = undefined;
-        }
+        else {
+            if (this.output1.value !== undefined && this.output1.oldValue !== undefined && !simulationArea.contentionPending.contains(this)) {
+              this.output1.value = undefined;
+              simulationArea.simulationQueue.add(this.output1);
+            }
+          }
+        this.output1.oldValue = this.output1.value;
+        simulationArea.contentionPending.clean(this);
     }
 
     /**

--- a/simulator/src/modules/TriState.js
+++ b/simulator/src/modules/TriState.js
@@ -74,14 +74,13 @@ export default class TriState extends CircuitElement {
                 this.output1.value = this.inp1.value; // >>>0)<<(32-this.bitWidth))>>>(32-this.bitWidth);
                 simulationArea.simulationQueue.add(this.output1);
             }
-            simulationArea.contentionPending.clean(this);
-        } else if (
-            this.output1.value !== undefined &&
-            !simulationArea.contentionPending.contains(this)
-        ) {
-            this.output1.value = undefined;
-            simulationArea.simulationQueue.add(this.output1);
+        } else {
+            if (this.output1.value !== undefined && this.output1.oldValue !== undefined && !simulationArea. contentionPending.contains(this)) {
+              this.output1.value = undefined;
+              simulationArea.simulationQueue.add(this.output1);
+            }
         }
+        this.output1.oldValue = this.output1.value;
         simulationArea.contentionPending.clean(this);
     }
 

--- a/simulator/src/node.js
+++ b/simulator/src/node.js
@@ -360,8 +360,12 @@ export default class Node {
 
             if (this.type == NODE_OUTPUT && !this.subcircuitOverride) {
                 if (this.parent.isResolvable() && !this.parent.queueProperties.inQueue) {
-                    if (this.parent.objectType == 'TriState') {
+                    if (this.parent.objectType == 'TriState' || this.parent.objectType == 'ControlledInverter') {
                         if (this.parent.state.value) { simulationArea.simulationQueue.add(this.parent); }
+                        else if (this.parent.state.value === 0) {
+                            this.parent.output1.value = undefined;
+                            simulationArea.simulationQueue.add(this.parent);
+                        }
                     } else {
                         simulationArea.simulationQueue.add(this.parent);
                     }
@@ -390,6 +394,9 @@ export default class Node {
                     showError(`Contention Error: ${this.value} and ${node.value} at ${circuitElementName} in ${circuitName}`);
                 } else if (node.bitWidth == this.bitWidth || node.type == 2) {
                     if (node.parent.objectType == 'TriState' && node.value != undefined && node.type == 1) {
+                        if (node.parent.state.value) { simulationArea.contentionPending.push(node.parent); }
+                    }
+                    if (node.parent.objectType == 'ControlledInverter' && node.value != undefined && node.type == 1) {
                         if (node.parent.state.value) { simulationArea.contentionPending.push(node.parent); }
                     }
 


### PR DESCRIPTION
### [**_GSOC_**](https://github.com/CircuitVerse/CircuitVerse/wiki/GSoC%2723-Project-List#project-3---simulator-stability-improvements)
**POC**

Fixes #244 

#### Describe the changes you have made in this PR -
1. [Node.js](https://github.com/CircuitVerse/CircuitVerse/blob/master/simulator/src/node.js#L363) Added, a condition that propagates an X state instead when tristate is in a high impedance state.
2. Fixed Controlled Inverter.
3. Fixed  (When the enable pin of the tristate buffer is grounded, not passing through the input, it will cause a Simulation Stack Limit Exceeded error if the output is connected to the input.)

### Screenshots of the changes (If any) -

[Tristate.webm](https://user-images.githubusercontent.com/89515816/226210860-1358fc1f-b2d9-45e6-a57a-c7109548de0e.webm)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
