### PR TITLE
There should be a way to identify the currently selected component (o…

### DIFF
--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -27,7 +27,8 @@ import { showProperties } from './ux';
 import {
     scheduleUpdate, updateSimulationSet,
     updateCanvasSet, updateSubcircuitSet,
-    forceResetNodesSet, changeLightMode,
+    forceResetNodesSet, changeLightMode, simulationLog, simulation,
+    //  simulationLog, play,
 } from './engine';
 import { toggleLayoutMode, layoutModeGet } from './layoutMode';
 import { setProjectName, getProjectName } from './data/save';
@@ -374,4 +375,21 @@ export default class Scope {
         this.ox = (-minX) * this.scale + (width - (maxX - minX) * this.scale) / 2;
         this.oy = (-minY) * this.scale + (height - ytoolbarOffset - (maxY - minY) * this.scale) / 2;
     }
+
+    getCurrentlySelectedComponent() {
+         return simulationArea.lastSelected;
+    }
+
+    getAllSelectedComponent() {
+        return simulationArea.multipleObjectSelections;
+    }
+
+    getSimulationLog() {
+        return simulationLog();
+    }
+
+    getStepCount() {
+     return simulation();
+    }
+
 }

--- a/simulator/src/engine.js
+++ b/simulator/src/engine.js
@@ -373,6 +373,8 @@ export function updateSelectionsAndPane(scope = globalScope) {
  * @param {boolean} resetNodes - boolean to reset all nodes
  * @category engine
  */
+let simulation_log = [];
+let valueue;
 export function play(scope = globalScope, resetNodes = false) {
     if (errorDetected) return; // Don't simulate until error is fixed
     if (loading === true) return; // Don't simulate until loaded
@@ -403,17 +405,34 @@ export function play(scope = globalScope, resetNodes = false) {
         elem.resolve();
         stepCount++;
         if (stepCount > 1000000) { // Cyclic or infinite Circuit Detection
+            simulation_log.push(elem);
             showError('Simulation Stack limit exceeded: maybe due to cyclic paths or contention');
             errorDetectedSet(true);
             forceResetNodesSet(true);
         }
     }
+    valueue = stepCount;
+
     // Check for TriState Contentions
     if (simulationArea.contentionPending.length) {
         showError('Contention at TriState');
         forceResetNodesSet(true);
         errorDetectedSet(true);
     }
+    // valueue = stepCount;
+}
+
+/**
+ *@param {number=} Simulation Log function
+ *@param {number=} This function is to get simulation Log
+ *@category engine
+ */
+ export function simulationLog() {
+    return simulation_log;
+}
+
+export function simulation() {
+    return valueue;
 }
 
 /**


### PR DESCRIPTION
…n the canvas) and In case of the 'Simulation Stack Exceeded' error, there should be a way to find the components that are being added to the simulation stack unnaturally large number of times.

Fixes #

#### Describe the changes you have made in this PR -

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
